### PR TITLE
Execute shell commands with file handling

### DIFF
--- a/src/pipex.c
+++ b/src/pipex.c
@@ -16,11 +16,16 @@
  a pipe and then close with the exec function */
 void	child_process(char **argv, char **envp, int *fd)
 {
-	int		filein;
+	int	filein;
 
 	filein = open(argv[1], O_RDONLY, 0777);
 	if (filein == -1)
+	{
 		ft_error("open infile");
+		close(fd[1]);
+		close(fd[0]);
+		exit(1);
+	}
 	dup2(fd[1], STDOUT_FILENO);
 	dup2(filein, STDIN_FILENO);
 	close(fd[0]);
@@ -31,11 +36,16 @@ void	child_process(char **argv, char **envp, int *fd)
  fileout and also close with the exec function */
 void	parent_process(char **argv, char **envp, int *fd)
 {
-	int		fileout;
+	int	fileout;
 
 	fileout = open(argv[4], O_WRONLY | O_CREAT | O_TRUNC, 0777);
 	if (fileout == -1)
+	{
 		ft_error("open outfile");
+		close(fd[1]);
+		close(fd[0]);
+		exit(1);
+	}
 	dup2(fd[0], STDIN_FILENO);
 	dup2(fileout, STDOUT_FILENO);
 	close(fd[1]);

--- a/src/utils.c
+++ b/src/utils.c
@@ -44,10 +44,9 @@ char	*find_path(char *cmd, char **envp)
 }
 
 /* A simple error displaying function. */
-void	ft_error(const char *msg, int code)
+void	ft_error(const char *msg)
 {
 	perror(msg);
-	exit(code);
 }
 
 /* Function that take the command and send it to find_path
@@ -66,10 +65,10 @@ void	execute(char *argv, char **envp)
 		while (cmd[++i])
 			free(cmd[i]);
 		free(cmd);
-		ft_error("command not found", 127);
+		ft_error("command not found");
 	}
 	if (execve(path, cmd, envp) == -1)
-		ft_error("execve", 1);
+		ft_error("execve");
 }
 
 /* Function that will read input from the terminal and return line. */


### PR DESCRIPTION
Decouple `exit` from `ft_error` to allow explicit error handling and resource cleanup.

Previously, `ft_error` would immediately terminate the program. This change modifies `ft_error` to only print error messages, allowing calling functions to handle resource cleanup and program termination (e.g., `exit`) as needed, preventing immediate "FATAL ERROR" exits.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c101cc1-4109-40d7-8552-574cfb02c3a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c101cc1-4109-40d7-8552-574cfb02c3a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

