### PR TITLE
Execute failing command with output redirection

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -66,9 +66,17 @@ void	execute(char *argv, char **envp)
 			free(cmd[i]);
 		free(cmd);
 		ft_error("command not found");
+		exit(127); // POSIX: command not found
 	}
 	if (execve(path, cmd, envp) == -1)
+	{
+		while (cmd[++i])
+			free(cmd[i]);
+		free(cmd);
+		free(path);
 		ft_error("execve");
+		exit(126); // POSIX: command found but not executable
+	}
 }
 
 /* Function that will read input from the terminal and return line. */


### PR DESCRIPTION
Add POSIX-compliant exit codes and memory cleanup in `execute()` to fix incorrect exit statuses and memory leaks on command execution failures.

Previously, `execute()` did not exit on command not found or `execve` failure, leading to incorrect shell exit statuses and potential memory leaks of `cmd` and `path` variables. This change ensures `exit(127)` for command not found and `exit(126)` for execution failures, while also freeing allocated memory.

---
<a href="https://cursor.com/background-agent?bcId=bc-752cfbfe-9180-4553-b89f-cd6bda926b36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-752cfbfe-9180-4553-b89f-cd6bda926b36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

