### PR TITLE
Run command with file redirection and memory leak check

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -21,6 +21,8 @@ char	*find_path(char *cmd, char **envp)
 	int		i;
 	char	*part_path;
 
+	if (!cmd || !*cmd) // 追加: コマンドがNULLまたは空文字列なら即return
+		return (0);
 	i = 0;
 	while (ft_strnstr(envp[i], "PATH", 4) == 0)
 		i++;
@@ -32,7 +34,13 @@ char	*find_path(char *cmd, char **envp)
 		path = ft_strjoin(part_path, cmd);
 		free(part_path);
 		if (access(path, F_OK) == 0)
+		{
+			int j = 0;
+			while (paths[j])
+				free(paths[j++]);
+			free(paths);
 			return (path);
+		}
 		free(path);
 		i++;
 	}
@@ -59,6 +67,16 @@ void	execute(char *argv, char **envp)
 
 	i = -1;
 	cmd = ft_split(argv, ' ');
+	if (!cmd || !cmd[0] || !*cmd[0]) // 追加: コマンドが空なら即エラー&解放
+	{
+		if (cmd) {
+			while (cmd[++i])
+				free(cmd[i]);
+			free(cmd);
+		}
+		ft_error("command not found");
+		exit(1);
+	}
 	path = find_path(cmd[0], envp);
 	if (!path)
 	{
@@ -66,6 +84,7 @@ void	execute(char *argv, char **envp)
 			free(cmd[i]);
 		free(cmd);
 		ft_error("command not found");
+		exit(1);
 	}
 	if (execve(path, cmd, envp) == -1)
 		ft_error("execve");


### PR DESCRIPTION
Handle empty or NULL commands in `execute` and `find_path` to prevent errors and memory leaks.

Previously, passing an empty string (`""`) as a command in the pipeline could lead to `ft_split` returning an array where `cmd[0]` was NULL or empty. This caused `find_path` to receive invalid input, resulting in undefined behavior, test failures (#24), and memory leaks (#25). This PR adds explicit checks and error handling for these cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c01a155-edd2-4484-b768-a871d1f9fe84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c01a155-edd2-4484-b768-a871d1f9fe84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

