### PR TITLE
Fix failing mandatory and bonus tests

### DIFF
--- a/src/pipex.c
+++ b/src/pipex.c
@@ -42,7 +42,7 @@ static void	parent_process(char **argv, char **envp, int *fd)
 	execute(argv[3], envp);
 }
 
-static int	wait_children(pid_t pid1, pid_t pid2, int infile_error)
+static int	wait_children(pid_t pid1, pid_t pid2)
 {
 	int	status1;
 	int	status2;
@@ -57,8 +57,6 @@ static int	wait_children(pid_t pid1, pid_t pid2, int infile_error)
 		exit_code = 128 + WTERMSIG(status2);
 	else
 		exit_code = 1;
-	if (pid1 <= 0 && infile_error && exit_code == 0)
-		return (1);
 	if (pid2 <= 0 && pid1 > 0)
 	{
 		if (WIFEXITED(status1))
@@ -105,5 +103,5 @@ int	main(int argc, char **argv, char **envp)
 		parent_process(argv, envp, fd);
 	close(fd[0]);
 	close(fd[1]);
-	return (wait_children(pid1, pid2, infile_error));
+	return (wait_children(pid1, pid2));
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -62,7 +62,7 @@ char	*find_path(char *cmd, char **envp)
 	if (!cmd || !envp)
 		return (0);
 	i = 0;
-	while (envp[i] && ft_strnstr(envp[i], "PATH", 4) == 0)
+	while (envp[i] && ft_strncmp(envp[i], "PATH=", 5) != 0)
 		i++;
 	if (!envp[i])
 		return (0);


### PR DESCRIPTION
Refactor `wait_children` to correctly propagate exit codes for commands with non-existent input files, matching shell behavior.
Update `find_path` to strictly filter for `PATH=` environment variables, improving command resolution for multiple pipes.

---
<a href="https://cursor.com/background-agent?bcId=bc-cede37d3-963a-4d3a-9bbe-8b31868ce1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cede37d3-963a-4d3a-9bbe-8b31868ce1d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

